### PR TITLE
Patch: Update image version for openproblems/base_* images

### DIFF
--- a/src/data_processors/process_dataset/config.vsh.yaml
+++ b/src/data_processors/process_dataset/config.vsh.yaml
@@ -26,7 +26,7 @@ test_resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_spatialdata_partial.yaml
   - type: native

--- a/src/datasets/loaders/allen_brain_cell_atlas/config.vsh.yaml
+++ b/src/datasets/loaders/allen_brain_cell_atlas/config.vsh.yaml
@@ -97,7 +97,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         packages: 

--- a/src/datasets/loaders/tenx_xenium/config.vsh.yaml
+++ b/src/datasets/loaders/tenx_xenium/config.vsh.yaml
@@ -56,7 +56,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi:

--- a/src/datasets/loaders/vizgen_merscope/config.vsh.yaml
+++ b/src/datasets/loaders/vizgen_merscope/config.vsh.yaml
@@ -56,7 +56,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_spatialdata_partial.yaml
     setup:

--- a/src/datasets/loaders/wu_human_breast_cancer_sc/config.vsh.yaml
+++ b/src/datasets/loaders/wu_human_breast_cancer_sc/config.vsh.yaml
@@ -70,7 +70,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
   - type: native

--- a/src/datasets/processors/crop_region/config.vsh.yaml
+++ b/src/datasets/processors/crop_region/config.vsh.yaml
@@ -34,7 +34,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_spatialdata_partial.yaml
 

--- a/src/methods_calculate_cell_volume/alpha_shapes/config.vsh.yaml
+++ b/src/methods_calculate_cell_volume/alpha_shapes/config.vsh.yaml
@@ -23,7 +23,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
       - /src/base/setup_spatialdata_partial.yaml

--- a/src/methods_cell_type_annotation/moscot/config.vsh.yaml
+++ b/src/methods_cell_type_annotation/moscot/config.vsh.yaml
@@ -47,7 +47,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi: [numpy, anndata, scanpy, moscot, flax, diffrax]

--- a/src/methods_cell_type_annotation/ssam/config.vsh.yaml
+++ b/src/methods_cell_type_annotation/ssam/config.vsh.yaml
@@ -23,7 +23,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
     setup:

--- a/src/methods_cell_type_annotation/tacco/config.vsh.yaml
+++ b/src/methods_cell_type_annotation/tacco/config.vsh.yaml
@@ -16,7 +16,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi: [anndata, numpy, tacco]

--- a/src/methods_count_aggregation/basic_count_aggregation/config.vsh.yaml
+++ b/src/methods_count_aggregation/basic_count_aggregation/config.vsh.yaml
@@ -16,7 +16,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
       - /src/base/setup_spatialdata_partial.yaml

--- a/src/methods_expression_correction/gene_efficiency_correction/config.vsh.yaml
+++ b/src/methods_expression_correction/gene_efficiency_correction/config.vsh.yaml
@@ -26,7 +26,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
   - type: native

--- a/src/methods_expression_correction/resolvi_correction/config.vsh.yaml
+++ b/src/methods_expression_correction/resolvi_correction/config.vsh.yaml
@@ -42,7 +42,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
     setup:

--- a/src/methods_normalization/normalize_by_volume/config.vsh.yaml
+++ b/src/methods_normalization/normalize_by_volume/config.vsh.yaml
@@ -16,7 +16,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
   - type: native

--- a/src/methods_qc_filter/basic_qc_filter/config.vsh.yaml
+++ b/src/methods_qc_filter/basic_qc_filter/config.vsh.yaml
@@ -28,7 +28,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
   - type: native

--- a/src/methods_segmentation/binning/config.vsh.yaml
+++ b/src/methods_segmentation/binning/config.vsh.yaml
@@ -21,7 +21,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi: spatialdata

--- a/src/methods_segmentation/cellpose/config.vsh.yaml
+++ b/src/methods_segmentation/cellpose/config.vsh.yaml
@@ -79,7 +79,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi: spatialdata

--- a/src/methods_segmentation/cellpose/config.vsh.yaml
+++ b/src/methods_segmentation/cellpose/config.vsh.yaml
@@ -83,6 +83,8 @@ engines:
     setup:
       - type: python
         pypi: spatialdata
+      - type: python
+        pypi: cellpose<4.0.0
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
   - type: native

--- a/src/methods_segmentation/cellpose/config.vsh.yaml
+++ b/src/methods_segmentation/cellpose/config.vsh.yaml
@@ -18,6 +18,9 @@ arguments:
   - name: --model_type
     type: string
     default: "cyto"
+  - name: --resample
+    type: boolean
+    default: True
   - name: --channel_axis
     type: string
     default: "None"
@@ -35,7 +38,7 @@ arguments:
     default: "None"
   - name: --diameter
     type: double
-    default: 30.0
+    default: 30.0 #default should be None with cellpose v4
   - name: --do_3D
     type: boolean
     default: False
@@ -54,12 +57,9 @@ arguments:
   - name: --tile_overlap
     type: double
     default: 0.1
-  - name: --resample
-    type: boolean
-    default: True
-  - name: --interp
-    type: boolean
-    default: True
+  #- name: --interp #Seems to be removed in v4
+  #  type: boolean
+  #  default: True
   - name: --flow_threshold
     type: double
     default: 0.4

--- a/src/methods_segmentation/cellpose/config.vsh.yaml
+++ b/src/methods_segmentation/cellpose/config.vsh.yaml
@@ -91,4 +91,4 @@ runners:
   - type: executable
   - type: nextflow
     directives:
-      label: [ midtime, lowcpu, lowmem ]
+      label: [ midtime, lowcpu, lowmem, gpu ]

--- a/src/methods_segmentation/custom_segmentation/config.vsh.yaml
+++ b/src/methods_segmentation/custom_segmentation/config.vsh.yaml
@@ -22,7 +22,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_spatialdata_partial.yaml
   - type: native

--- a/src/methods_segmentation/watershed/config.vsh.yaml
+++ b/src/methods_segmentation/watershed/config.vsh.yaml
@@ -163,7 +163,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     setup:
       - type: python
         pypi: spatialdata

--- a/src/methods_transcript_assignment/basic_transcript_assignment/config.vsh.yaml
+++ b/src/methods_transcript_assignment/basic_transcript_assignment/config.vsh.yaml
@@ -26,7 +26,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_spatialdata_partial.yaml
   - type: native

--- a/src/methods_transcript_assignment/pciSeq_transcript_assignment/config.vsh.yaml
+++ b/src/methods_transcript_assignment/pciSeq_transcript_assignment/config.vsh.yaml
@@ -149,7 +149,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_spatialdata_partial.yaml
       - /src/base/setup_txsim_partial.yaml

--- a/src/metrics/similarity/config.vsh.yaml
+++ b/src/metrics/similarity/config.vsh.yaml
@@ -89,7 +89,7 @@ resources:
 
 engines:
   - type: docker
-    image: openproblems/base_python:1.0.0
+    image: openproblems/base_python:1
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
       - /src/base/setup_spatialdata_partial.yaml


### PR DESCRIPTION
This PR updates the image version from :1.0.0 to :1 for `openproblems/base_*` images.