### PR TITLE
Adjust baysor docker container

### DIFF
--- a/src/methods_transcript_assignment/baysor/config.vsh.yaml
+++ b/src/methods_transcript_assignment/baysor/config.vsh.yaml
@@ -69,17 +69,41 @@ resources:
     path: script.py
 
 engines:
+  #NOTE: The docker container must be build with the correct platform. On mac viash test won't work. Rebuild the container
+  #      with the correct platform separately with the following command:
+  #      docker run -it --rm --platform linux/x86_64 python:3.11.13-bookworm /bin/bash
+  #      ... and then the commands to build the next layers.
   - type: docker
-    image: openproblems/base_python:1
-    __merge__: 
-      - /src/base/setup_spatialdata_partial.yaml
+    image: python:3.11.13-bookworm
     setup:
+      - type: apt
+        packages: procps
+      - type: python
+        github:
+          - openproblems-bio/core#subdirectory=packages/python/openproblems
+      - type: python
+        packages:
+           - spatialdata
       - type: docker
         run:
           - wget https://github.com/kharchenkolab/Baysor/releases/download/v0.7.1/baysor-x86_x64-linux-v0.7.1_build.zip
           - unzip baysor-x86_x64-linux-v0.7.1_build.zip
           - chmod +x /bin/baysor
           - ln -sf /bin/baysor/bin/baysor /usr/local/bin/baysor
+  #- type: docker
+  #  image: openproblems/base_python:1
+  #  __merge__: 
+  #    - /src/base/setup_spatialdata_partial.yaml
+  #  setup:
+  #    - type: docker
+  #      run:
+  #        - wget https://github.com/kharchenkolab/Baysor/releases/download/v0.7.1/baysor-x86_x64-linux-v0.7.1_build.zip
+  #        - unzip baysor-x86_x64-linux-v0.7.1_build.zip
+  #        - chmod +x /bin/baysor
+  #        - ln -sf /bin/baysor/bin/baysor /usr/local/bin/baysor
+  #        #- execstack -c /bin/baysor/bin/../lib/julia/libopenlibm.so
+  #        #Since the update of the base image we run into an issue that could be solved with execstack, however this package not 
+  #        #available for the given os version.
   - type: native
 
 runners:


### PR DESCRIPTION
# Why this PR is needed

A new error occured (probably due to the update to `openproblems/base_python:1` image). Baysor fails:
```bash
baysor
```
```
ERROR: Unable to load dependent library /usr/bin/baysor/bin/../lib/julia/libopenlibm.so
Message:/usr/bin/baysor/bin/../lib/julia/libopenlibm.so: cannot enable executable stack as shared object requires: Invalid argument
```

A solution that should work:
```bash
execstack -c /bin/baysor/bin/../lib/Julia/libopenlibm.so
```

Unfortunately this doesn't work since `execstack` is not installable in the os version of `openproblems/base_python:1` 
```bash
apt-get install -y execstack
```
```
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package execstack
```

The issue is that RWE appears when running:
```
readelf -W -l /usr/bin/baysor/bin/../lib/julia/libopenlibm.so | grep GNU_STACK
```
```
# RWE = executable stack, RW = non-exec
 GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RWE 0x10
```


# Solution in the PR

We build a new docker container that doesn't rely on the `openproblems/base_python:1` base image. Unfortunately when working with the `python:3.11.13-...` images I have the issue that I always need to define the platform, otherwise I run into an error on my mac:
```bash
baysor
```
```
rosetta error: failed to open elf at /lib64/ld-linux-x86-64.so.2
```

So instead of working with viash I developed the container on the side via 
```
docker run -it --rm --platform linux/x86_64 python:3.11.13-bookworm /bin/bash
```
followed by the commands that build the layers defined in the config.vsh.yaml