### PR TITLE
Add method selection arguments

### DIFF
--- a/scripts/run_benchmark/run_test_local.sh
+++ b/scripts/run_benchmark/run_test_local.sh
@@ -20,6 +20,16 @@ cat > /tmp/params.yaml << HERE
 id: mouse_brain_combined
 input_sc: resources_test/task_ist_preprocessing/mouse_brain_combined/scrnaseq_reference.h5ad
 input_sp: resources_test/task_ist_preprocessing/mouse_brain_combined/raw_ist.zarr
+default_methods:
+  - custom_segmentation
+  - basic_transcript_assignment
+  - basic_count_aggregation
+  - basic_qc_filter
+  - alpha_shapes
+  - normalize_by_volume
+  - normalize_by_counts
+  - ssam
+  - no_correction
 segmentation_methods:
   - custom_segmentation
 segmentation_assignment_methods:

--- a/scripts/run_benchmark/run_test_local.sh
+++ b/scripts/run_benchmark/run_test_local.sh
@@ -27,7 +27,6 @@ default_methods:
   - basic_qc_filter
   - alpha_shapes
   - normalize_by_volume
-  - normalize_by_counts
   - ssam
   - no_correction
 segmentation_methods:
@@ -36,7 +35,7 @@ segmentation_methods:
   - binning
   #- stardist
   - watershed
-segmentation_assignment_methods:
+transcript_assignment_methods:
   - basic_transcript_assignment
   #- baysor
   - clustermap
@@ -49,9 +48,8 @@ qc_filtering_methods:
   - basic_qc_filter
 volume_calculation_methods:
   - alpha_shapes
-volume_normalization_methods:
+normalization_methods:
   - normalize_by_volume
-direct_normalization_methods:
   - normalize_by_counts
   - spanorm
 celltype_annotation_methods:

--- a/scripts/run_benchmark/run_test_local.sh
+++ b/scripts/run_benchmark/run_test_local.sh
@@ -15,13 +15,46 @@ echo "  Make sure to run 'scripts/project/build_all_docker_containers.sh'!"
 RUN_ID="testrun_$(date +%Y-%m-%d_%H-%M-%S)"
 publish_dir="temp/results/${RUN_ID}"
 
+# Write the parameters to file
+cat > /tmp/params.yaml << HERE
+id: mouse_brain_combined
+input_sc: resources_test/task_ist_preprocessing/mouse_brain_combined/scrnaseq_reference.h5ad
+input_sp: resources_test/task_ist_preprocessing/mouse_brain_combined/raw_ist.zarr
+segmentation_methods:
+  - custom_segmentation
+segmentation_assignment_methods:
+  - basic_transcript_assignment
+  - baysor
+  - clustermap
+  - pciseq
+  - comseg
+  - proseg
+count_aggregation_methods:
+  - basic_count_aggregation
+qc_filtering_methods:
+  - basic_qc_filter
+volume_calculation_methods:
+  - alpha_shapes
+volume_normalization_methods:
+  - normalize_by_volume
+direct_normalization_methods:
+  - normalize_by_counts
+  - spanorm
+celltype_annotation_methods:
+  - ssam
+  - tacco
+  - moscot
+expression_correction_methods:
+  - no_correction
+  - gene_efficiency_correction
+  - resolvi_correction
+output_state: "state.yaml"
+publish_dir: "$publish_dir"
+HERE
+
 nextflow run . \
   -main-script target/nextflow/workflows/run_benchmark/main.nf \
   -profile docker \
   -resume \
   -c common/nextflow_helpers/labels_ci.config \
-  --id mouse_brain_combined \
-  --input_sc resources_test/task_ist_preprocessing/mouse_brain_combined/scrnaseq_reference.h5ad \
-  --input_sp resources_test/task_ist_preprocessing/mouse_brain_combined/raw_ist.zarr \
-  --output_state state.yaml \
-  --publish_dir "$publish_dir"
+  -params-file /tmp/params.yaml

--- a/scripts/run_benchmark/run_test_local.sh
+++ b/scripts/run_benchmark/run_test_local.sh
@@ -32,9 +32,13 @@ default_methods:
   - no_correction
 segmentation_methods:
   - custom_segmentation
+  - cellpose
+  - binning
+  #- stardist
+  - watershed
 segmentation_assignment_methods:
   - basic_transcript_assignment
-  - baysor
+  #- baysor
   - clustermap
   - pciseq
   - comseg
@@ -53,7 +57,7 @@ direct_normalization_methods:
 celltype_annotation_methods:
   - ssam
   - tacco
-  - moscot
+  #- moscot
 expression_correction_methods:
   - no_correction
   - gene_efficiency_correction

--- a/src/base/setup_spatialdata_partial.yaml
+++ b/src/base/setup_spatialdata_partial.yaml
@@ -1,3 +1,3 @@
 setup:
   - type: python
-    pypi: [spatialdata]
+    pypi: [spatialdata, "anndata>=0.12.0"]

--- a/src/methods_cell_type_annotation/ssam/config.vsh.yaml
+++ b/src/methods_cell_type_annotation/ssam/config.vsh.yaml
@@ -25,6 +25,7 @@ engines:
   - type: docker
     image: openproblems/base_python:1
     __merge__: 
+      - /src/base/setup_spatialdata_partial.yaml
       - /src/base/setup_txsim_partial.yaml
     setup:
       - type: python

--- a/src/methods_cell_type_annotation/ssam/script.py
+++ b/src/methods_cell_type_annotation/ssam/script.py
@@ -26,7 +26,8 @@ adata_sp = ad.read_h5ad(par['input_spatial_normalized_counts'])
 transcripts = sd.SpatialData.read(par['input_transcript_assignments'])['transcripts']
 adata_sc = ad.read_h5ad(par['input_scrnaseq_reference'])
 adata_sc.X = adata_sc.layers["normalized"]
-adata_sp = adata_sp[:,adata_sc.var_names] #TODO: do we want to do this earlier? Maybe not, thinking about transcripts related quality metrics
+shared_genes = [g for g in adata_sc.var_names if g in adata_sp.var_names]
+adata_sp = adata_sp[:,shared_genes] #TODO: do we want to do this earlier? Maybe not, thinking about transcripts related quality metrics
 
 # Annotate cell types
 print('Annotating cell types', flush=True)

--- a/src/methods_segmentation/binning/config.vsh.yaml
+++ b/src/methods_segmentation/binning/config.vsh.yaml
@@ -22,11 +22,9 @@ resources:
 engines:
   - type: docker
     image: openproblems/base_python:1
-    setup:
-      - type: python
-        pypi: spatialdata
     __merge__: 
       - /src/base/setup_txsim_partial.yaml
+      - /src/base/setup_spatialdata_partial.yaml
   - type: native
 
 runners:

--- a/src/methods_segmentation/cellpose/config.vsh.yaml
+++ b/src/methods_segmentation/cellpose/config.vsh.yaml
@@ -82,10 +82,9 @@ engines:
     image: openproblems/base_python:1
     setup:
       - type: python
-        pypi: spatialdata
-      - type: python
         pypi: cellpose<4.0.0
     __merge__: 
+      - /src/base/setup_spatialdata_partial.yaml
       - /src/base/setup_txsim_partial.yaml
   - type: native
 

--- a/src/methods_segmentation/stardist/config.vsh.yaml
+++ b/src/methods_segmentation/stardist/config.vsh.yaml
@@ -25,9 +25,9 @@ engines:
   #       Installations can be done with pip (except tensorflow: use conda install -c conda-forge tensorflow)
   - type: docker
     image: openproblems/base_python:1
+    __merge__: 
+      - /src/base/setup_spatialdata_partial.yaml
     setup:
-      - type: python
-        pypi: spatialdata
       - type: python
         pypi: stardist
       - type: python

--- a/src/methods_segmentation/watershed/config.vsh.yaml
+++ b/src/methods_segmentation/watershed/config.vsh.yaml
@@ -164,10 +164,8 @@ resources:
 engines:
   - type: docker
     image: openproblems/base_python:1
-    setup:
-      - type: python
-        pypi: spatialdata
     __merge__: 
+      - /src/base/setup_spatialdata_partial.yaml
       - /src/base/setup_txsim_partial.yaml
   - type: native
 

--- a/src/methods_transcript_assignment/baysor/config.vsh.yaml
+++ b/src/methods_transcript_assignment/baysor/config.vsh.yaml
@@ -84,9 +84,9 @@ engines:
           - openproblems-bio/core#subdirectory=packages/python/openproblems
       - type: python
         packages:
-           - spatialdata
-           - anndata<0.12.0 #TODO: Remove this line when https://github.com/gustaveroussy/sopa/issues/305 is resolved
+           #TODO: Add merge with setup_spatialdata_partial.yaml and solve anndata version conflict differently
            - sopa[baysor]
+           - anndata<0.12.0 #TODO: Remove this line when https://github.com/gustaveroussy/sopa/issues/305 is resolved
       - type: docker
         run:
           - wget https://github.com/kharchenkolab/Baysor/releases/download/v0.7.1/baysor-x86_x64-linux-v0.7.1_build.zip

--- a/src/methods_transcript_assignment/comseg/config.vsh.yaml
+++ b/src/methods_transcript_assignment/comseg/config.vsh.yaml
@@ -73,18 +73,13 @@ resources:
 engines:
   - type: docker
     image: openproblems/base_python:1
+    __merge__: 
+      - /src/base/setup_spatialdata_partial.yaml
     setup:
       - type: python
         pypi: 
-          - spatialdata
           - sopa
-          - anndata
-          - pandas
-          - numpy
-          - xarray
-          - scikit-image
           - comseg
-          - scipy
 
   - type: native
 

--- a/src/metrics/similarity/script.py
+++ b/src/metrics/similarity/script.py
@@ -36,6 +36,10 @@ assert adata_sc.obs['cell_type'].notna().all(), "There are nan values in the cel
 assert (adata_sp.obs['cell_type'] != "None").all(), "There are None values in the cell type annotations of the spatial data"
 assert (adata_sc.obs['cell_type'] != "None").all(), "There are None values in the cell type annotations of the scRNAseq data"
 
+# Subset to shared genes #TODO: Check if some metrics are affected by this
+shared_genes = [g for g in adata_sc.var_names if g in adata_sp.var_names]
+adata_sp = adata_sp[:,shared_genes]
+adata_sc = adata_sc[:,shared_genes]
 
 print('Compute metrics', flush=True)
 df_filtered = tx.metrics.all_metrics(

--- a/src/workflows/run_benchmark/config.vsh.yaml
+++ b/src/workflows/run_benchmark/config.vsh.yaml
@@ -46,7 +46,17 @@ argument_groups:
     description: |
       Use these arguments to select which methods are run for each processing
       step. Only the methods provided to these arguments will be run.
+
+      If a method is NOT in `default_methods` it will only be run in combination
+      with the default methods.
     arguments:
+      - name: "--default_methods"
+        description: |
+          A list of default methods that are always run in combination with all
+          other methods. If this is set it should contain a single method from
+          each step.
+        type: string
+        multiple: true
       - name: "--segmentation_methods"
         description: |
           A list of segmentation methods to run.

--- a/src/workflows/run_benchmark/config.vsh.yaml
+++ b/src/workflows/run_benchmark/config.vsh.yaml
@@ -42,6 +42,65 @@ argument_groups:
         required: true
         direction: output
         default: task_info.yaml
+  - name: Method selection
+    description: |
+      Use these arguments to select which methods are run for each processing
+      step. Only the methods provided to these arguments will be run.
+    arguments:
+      - name: "--segmentation_methods"
+        description: |
+          A list of segmentation methods to run.
+        type: string
+        multiple: true
+        default: "custom_segmentation:cellpose:binning:stardist:watershed"
+      - name: "--segmentation_assignment_methods"
+        description: |
+          A list of segmentation assignment methods to run.
+        type: string
+        multiple: true
+        default: "basic_transcript_assignment:baysor:clustermap:pciseq:comseg:proseg"
+      - name: "--count_aggregation_methods"
+        description: |
+          A list of count aggregation methods to run.
+        type: string
+        multiple: true
+        default: "basic_count_aggregation"
+      - name: "--qc_filtering_methods"
+        description: |
+          A list of QC filtering methods to run.
+        type: string
+        multiple: true
+        default: "basic_qc_filter"
+      - name: "--volume_calculation_methods"
+        description: |
+          A list of volume calculation methods to run.
+        type: string
+        multiple: true
+        default: "alpha_shapes"
+      - name: "--volume_normalization_methods"
+        description: |
+          A list of volume normalization methods to run.
+        type: string
+        multiple: true
+        default: "normalize_by_volume"
+      - name: "--direct_normalization_methods"
+        description: |
+          A list of direct normalization methods to run.
+        type: string
+        multiple: true
+        default: "normalize_by_counts:spanorm"
+      - name: "--celltype_annotation_methods"
+        description: |
+          A list of cell type annotation methods to run.
+        type: string
+        multiple: true
+        default: "ssam:tacco:moscot"
+      - name: "--expression_correction_methods"
+        description: |
+          A list of expression correction methods to run.
+        type: string
+        multiple: true
+        default: "no_correction:gene_efficiency_correction:resolvi_correction"
 
 resources:
   - type: nextflow_script
@@ -49,6 +108,7 @@ resources:
     entrypoint: run_wf
   - type: file
     path: /_viash.yaml
+  - path: /common/nextflow_helpers/helper.nf
 
 dependencies:
   - name: utils/extract_uns_metadata

--- a/src/workflows/run_benchmark/config.vsh.yaml
+++ b/src/workflows/run_benchmark/config.vsh.yaml
@@ -63,9 +63,9 @@ argument_groups:
         type: string
         multiple: true
         default: "custom_segmentation:cellpose:binning:stardist:watershed"
-      - name: "--segmentation_assignment_methods"
+      - name: "--transcript_assignment_methods"
         description: |
-          A list of segmentation assignment methods to run.
+          A list of transcript assignment methods to run.
         type: string
         multiple: true
         default: "basic_transcript_assignment:baysor:clustermap:pciseq:comseg:proseg"
@@ -87,18 +87,12 @@ argument_groups:
         type: string
         multiple: true
         default: "alpha_shapes"
-      - name: "--volume_normalization_methods"
+      - name: "--normalization_methods"
         description: |
-          A list of volume normalization methods to run.
+          A list of normalization methods to run.
         type: string
         multiple: true
-        default: "normalize_by_volume"
-      - name: "--direct_normalization_methods"
-        description: |
-          A list of direct normalization methods to run.
-        type: string
-        multiple: true
-        default: "normalize_by_counts:spanorm"
+        default: "normalize_by_volume:normalize_by_counts:spanorm"
       - name: "--celltype_annotation_methods"
         description: |
           A list of cell type annotation methods to run.

--- a/src/workflows/run_benchmark/main.nf
+++ b/src/workflows/run_benchmark/main.nf
@@ -147,7 +147,7 @@ workflow run_wf {
       filter: { id, state, comp ->
         checkRunMethod(
           comp.config.name,
-          state.segmentation_assignment_methods,
+          state.transcript_assignment_methods,
           state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
@@ -327,7 +327,7 @@ workflow run_wf {
       filter: { id, state, comp ->
         checkRunMethod(
           comp.config.name,
-          state.volume_normalization_methods,
+          state.normalization_methods,
           state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
@@ -367,7 +367,7 @@ workflow run_wf {
       filter: { id, state, comp ->
         checkRunMethod(
           comp.config.name,
-          state.direct_normalization_methods,
+          state.normalization_methods,
           state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )

--- a/src/workflows/run_benchmark/main.nf
+++ b/src/workflows/run_benchmark/main.nf
@@ -105,7 +105,7 @@ workflow run_wf {
         checkRunMethod(
           comp.config.name,
           state.segmentation_methods,
-          state.steps.collect{it.component_id} + [comp.name],
+          state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
       },
@@ -148,7 +148,7 @@ workflow run_wf {
         checkRunMethod(
           comp.config.name,
           state.segmentation_assignment_methods,
-          state.steps.collect{it.component_id} + [comp.name],
+          state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
       },
@@ -221,7 +221,7 @@ workflow run_wf {
         checkRunMethod(
           comp.config.name,
           state.count_aggregation_methods,
-          state.steps.collect{it.component_id} + [comp.name],
+          state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
       },
@@ -257,7 +257,7 @@ workflow run_wf {
         checkRunMethod(
           comp.config.name,
           state.qc_filtering_methods,
-          state.steps.collect{it.component_id} + [comp.name],
+          state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
       },
@@ -293,7 +293,7 @@ workflow run_wf {
         checkRunMethod(
           comp.config.name,
           state.volume_calculation_methods,
-          state.steps.collect{it.component_id} + [comp.name],
+          state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
       },
@@ -328,7 +328,7 @@ workflow run_wf {
         checkRunMethod(
           comp.config.name,
           state.volume_normalization_methods,
-          state.steps.collect{it.component_id} + [comp.name],
+          state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
       },
@@ -368,7 +368,7 @@ workflow run_wf {
         checkRunMethod(
           comp.config.name,
           state.direct_normalization_methods,
-          state.steps.collect{it.component_id} + [comp.name],
+          state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
       },
@@ -411,7 +411,7 @@ workflow run_wf {
         checkRunMethod(
           comp.config.name,
           state.celltype_annotation_methods,
-          state.steps.collect{it.component_id} + [comp.name],
+          state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
       },
@@ -450,7 +450,7 @@ workflow run_wf {
         checkRunMethod(
           comp.config.name,
           state.expression_correction_methods,
-          state.steps.collect{it.component_id} + [comp.name],
+          state.steps.collect{it.component_id}.findAll{it != null} + [comp.name],
           state.default_methods
         )
       },

--- a/src/workflows/run_benchmark/main.nf
+++ b/src/workflows/run_benchmark/main.nf
@@ -1,5 +1,24 @@
 include { checkItemAllowed } from "${meta.resources_dir}/helper.nf"
 
+Boolean checkDefaultMethods(List steps, List default_methods) {
+  if (!default_methods || default_methods.size() == 0) {
+    return true
+  }
+
+  if (!steps || steps.size() == 0) {
+    return true
+  }
+
+  def non_default_count = steps.findAll { !(it in default_methods) }.size()
+
+  return non_default_count <= 1
+}
+
+Boolean checkRunMethod(String method, List selected_methods, List steps, List default_methods) {
+  checkItemAllowed(method, selected_methods, null, "selected_methods", "NA") &&
+    checkDefaultMethods(steps, default_methods)
+}
+
 workflow auto {
   findStates(params, meta.config)
     | meta.workflow.run(
@@ -83,12 +102,11 @@ workflow run_wf {
     | runEach(
       components: segm_methods,
       filter: { id, state, comp ->
-        checkItemAllowed(
+        checkRunMethod(
           comp.config.name,
           state.segmentation_methods,
-          null,
-          "segmentation_methods",
-          "NA"
+          state.steps.collect{it.component_id} + [comp.name],
+          state.default_methods
         )
       },
       id: { id, state, comp ->
@@ -127,12 +145,11 @@ workflow run_wf {
     | runEach(
       components: segm_ass_methods,
       filter: { id, state, comp ->
-        checkItemAllowed(
+        checkRunMethod(
           comp.config.name,
           state.segmentation_assignment_methods,
-          null,
-          "segmentation_assignment_methods",
-          "NA"
+          state.steps.collect{it.component_id} + [comp.name],
+          state.default_methods
         )
       },
       id: { id, state, comp ->
@@ -201,12 +218,11 @@ workflow run_wf {
     | runEach(
       components: count_aggr_methods,
       filter: { id, state, comp ->
-        checkItemAllowed(
+        checkRunMethod(
           comp.config.name,
           state.count_aggregation_methods,
-          null,
-          "count_aggregation_methods",
-          "NA"
+          state.steps.collect{it.component_id} + [comp.name],
+          state.default_methods
         )
       },
       id: { id, state, comp ->
@@ -238,12 +254,11 @@ workflow run_wf {
     | runEach(
       components: qc_filter_methods,
       filter: { id, state, comp ->
-        checkItemAllowed(
+        checkRunMethod(
           comp.config.name,
           state.qc_filtering_methods,
-          null,
-          "qc_filtering_methods",
-          "NA"
+          state.steps.collect{it.component_id} + [comp.name],
+          state.default_methods
         )
       },
       id: { id, state, comp ->
@@ -275,12 +290,11 @@ workflow run_wf {
     | runEach(
       components: cell_vol_methods,
       filter: { id, state, comp ->
-        checkItemAllowed(
+        checkRunMethod(
           comp.config.name,
           state.volume_calculation_methods,
-          null,
-          "volume_calculation_methods",
-          "NA"
+          state.steps.collect{it.component_id} + [comp.name],
+          state.default_methods
         )
       },
       id: { id, state, comp ->
@@ -311,12 +325,11 @@ workflow run_wf {
     | runEach(
       components: vol_norm_methods,
       filter: { id, state, comp ->
-        checkItemAllowed(
+        checkRunMethod(
           comp.config.name,
           state.volume_normalization_methods,
-          null,
-          "volume_normalization_methods",
-          "NA"
+          state.steps.collect{it.component_id} + [comp.name],
+          state.default_methods
         )
       },
       id: { id, state, comp ->
@@ -348,17 +361,15 @@ workflow run_wf {
     normalize_by_counts,
     spanorm
   ]
-  //direct_norm_ch = Channel.empty()
   direct_norm_ch = qc_filter_ch
     | runEach(
       components: direct_norm_methods,
       filter: { id, state, comp ->
-        checkItemAllowed(
+        checkRunMethod(
           comp.config.name,
           state.direct_normalization_methods,
-          null,
-          "direct_normalization_methods",
-          "NA"
+          state.steps.collect{it.component_id} + [comp.name],
+          state.default_methods
         )
       },
       id: { id, state, comp ->
@@ -397,12 +408,11 @@ workflow run_wf {
     | runEach(
       components: cta_methods,
       filter: { id, state, comp ->
-        checkItemAllowed(
+        checkRunMethod(
           comp.config.name,
           state.celltype_annotation_methods,
-          null,
-          "celltype_annotation_methods",
-          "NA"
+          state.steps.collect{it.component_id} + [comp.name],
+          state.default_methods
         )
       },
       id: { id, state, comp ->
@@ -437,12 +447,11 @@ workflow run_wf {
     | runEach(
       components: expr_corr_methods,
       filter: { id, state, comp ->
-        checkItemAllowed(
+        checkRunMethod(
           comp.config.name,
           state.expression_correction_methods,
-          null,
-          "expression_correction_methods",
-          "NA"
+          state.steps.collect{it.component_id} + [comp.name],
+          state.default_methods
         )
       },
       id: { id, state, comp ->


### PR DESCRIPTION
## Describe your changes

<!-- Describe your changes  -->

Add arguments to the benchmark workflow that allow selecting the methods that are run for each step. There is also a `default_methods` argument. If this is set, any non-default methods will only be run in combination with the default methods.

The `run_test_local.sh` script has been updated to show how these can be set using a `params.yaml` file.

## Checklist before requesting a review
- [x] I have performed a self-review of my code

- Check the correct box. Does this PR contain:
  - [ ] Breaking changes
  - [x] New functionality
  - [ ] Major changes
  - [ ] Minor changes
  - [ ] Bug fixes

- [ ] Proposed changes are described in the CHANGELOG.md

- [ ] CI Tests succeed and look good!